### PR TITLE
GM-78 프로필 사진 업로드 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### security
 /src/main/resources/application-oauth.yml
+/src/main/resources/secret.yml

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+
     implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0")
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
 

--- a/src/main/java/com/gaaji/auth/adaptor/S3Uploader.java
+++ b/src/main/java/com/gaaji/auth/adaptor/S3Uploader.java
@@ -1,0 +1,7 @@
+package com.gaaji.auth.adaptor;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface S3Uploader {
+    String upload(MultipartFile multipartFile);
+}

--- a/src/main/java/com/gaaji/auth/adaptor/S3UploaderImpl.java
+++ b/src/main/java/com/gaaji/auth/adaptor/S3UploaderImpl.java
@@ -1,0 +1,87 @@
+package com.gaaji.auth.adaptor;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Service
+public class S3UploaderImpl implements S3Uploader {
+
+
+    private final AmazonS3Client amazonS3Client;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public String upload(MultipartFile multipartFile) {
+        try {
+            validateIsClientSendImageFile(multipartFile);
+            return uploadFiles(multipartFile, "gaaji/profile");
+        } catch (IOException e) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private void validateIsClientSendImageFile(MultipartFile multipartFile) {
+        if (!Objects.requireNonNull(multipartFile.getContentType()).contains("image")) {
+            throw new RuntimeException(); // FileTypeNotImageFileException()
+        }
+    }
+
+    private String uploadFiles(MultipartFile multipartFile, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile)  // 파일 변환할 수 없으면 에러
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "error: MultipartFile -> File convert fail"));
+        return upload(uploadFile, dirName);
+    }
+
+    private String upload(File uploadFile, String filePath) {
+        String fileName =
+                filePath + "/" + UUID.randomUUID() + uploadFile.getName();   // S3에 저장된 파일 이름
+        String uploadImageUrl = putS3(uploadFile, fileName); // s3로 업로드
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+    // S3로 업로드
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, uploadFile).withCannedAcl(
+                CannedAccessControlList.PublicRead));
+        return amazonS3Client.getUrl(bucket, fileName).toString();
+    }
+
+    // 로컬에 저장된 이미지 지우기
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            System.out.println("File delete success");
+            return;
+        }
+        System.out.println("File delete fail");
+    }
+
+    // 로컬에 파일 업로드 하기
+    private Optional<File> convert(MultipartFile file) throws IOException {
+        File convertFile = new File(
+                System.getProperty("user.dir") + "/" + file.getOriginalFilename());
+        if (convertFile.createNewFile()) { // 바로 위에서 지정한 경로에 File이 생성됨 (경로가 잘못되었다면 생성 불가능)
+            try (FileOutputStream fos = new FileOutputStream(
+                    convertFile)) { // FileOutputStream 데이터를 파일에 바이트 스트림으로 저장하기 위함
+                fos.write(file.getBytes());
+            }
+            return Optional.of(convertFile);
+        }
+        return Optional.empty();
+    }
+
+}

--- a/src/main/java/com/gaaji/auth/adaptor/Sample.java
+++ b/src/main/java/com/gaaji/auth/adaptor/Sample.java
@@ -1,5 +1,0 @@
-package com.gaaji.auth.adaptor;
-
-public class Sample {
-
-}

--- a/src/main/java/com/gaaji/auth/applicationservice/AuthRetrieveServiceImpl.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/AuthRetrieveServiceImpl.java
@@ -20,6 +20,6 @@ public class AuthRetrieveServiceImpl implements
     public RetrieveResponse retrieveAuth(String authId) {
         Auth auth = authRepository.findById(authId)
                 .orElseThrow();
-        return RetrieveResponse.of(authId, auth.getNickname(), auth.getMannerTemperature());
+        return RetrieveResponse.of(authId, auth.getNickname(), auth.getMannerTemperature(), auth.getProfilePictureUrl());
     }
 }

--- a/src/main/java/com/gaaji/auth/applicationservice/NicknameRegisterServiceImpl.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/NicknameRegisterServiceImpl.java
@@ -18,7 +18,7 @@ public class NicknameRegisterServiceImpl implements NicknameRegisterService{
     public void registerNickname(String authId, String nickname){
         Auth auth = authRepository
                 .findById(authId)
-                .orElseThrow(AuthIdNotFoundException::new); // TODO Exception 추가
+                .orElseThrow(AuthIdNotFoundException::new);
 
         auth.registerNickname(nickname);
     }

--- a/src/main/java/com/gaaji/auth/applicationservice/ProfilePictureUploadService.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/ProfilePictureUploadService.java
@@ -1,0 +1,9 @@
+package com.gaaji.auth.applicationservice;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ProfilePictureUploadService {
+
+    void uploadPicture(MultipartFile multipartFile, String authId);
+
+}

--- a/src/main/java/com/gaaji/auth/applicationservice/ProfilePictureUploadServiceImpl.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/ProfilePictureUploadServiceImpl.java
@@ -1,0 +1,35 @@
+package com.gaaji.auth.applicationservice;
+
+import com.gaaji.auth.adaptor.S3Uploader;
+import com.gaaji.auth.domain.Auth;
+import com.gaaji.auth.exception.AuthIdNotFoundException;
+import com.gaaji.auth.repository.AuthRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class ProfilePictureUploadServiceImpl implements
+        ProfilePictureUploadService {
+
+    private final S3Uploader s3Uploader;
+    private final AuthRepository authRepository;
+
+    @Override
+    public void uploadPicture(MultipartFile multipartFile, String authId) {
+        getMember(authId)
+                .registerProfilePicture(uploadImage(multipartFile));
+    }
+
+    private String uploadImage(MultipartFile multipartFile) {
+        return s3Uploader.upload(multipartFile);
+    }
+
+    private Auth getMember(String authId) {
+        return authRepository.findById(authId)
+                .orElseThrow(AuthIdNotFoundException::new);
+    }
+}

--- a/src/main/java/com/gaaji/auth/config/S3Config.java
+++ b/src/main/java/com/gaaji/auth/config/S3Config.java
@@ -1,0 +1,28 @@
+package com.gaaji.auth.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey,secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+                .build();
+    }
+}

--- a/src/main/java/com/gaaji/auth/controller/NicknameRegisterController.java
+++ b/src/main/java/com/gaaji/auth/controller/NicknameRegisterController.java
@@ -3,6 +3,7 @@ package com.gaaji.auth.controller;
 import com.gaaji.auth.applicationservice.NicknameRegisterService;
 import com.gaaji.auth.controller.dto.NicknameRegisterRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,14 +17,14 @@ public class NicknameRegisterController {
     private final NicknameRegisterService nicknameRegisterService;
 
     @PatchMapping("/auth/nickname")
-    public ResponseEntity<Void> registerNickname(@RequestHeader("AUTH-ID") String authId, @RequestBody NicknameRegisterRequest dto){
+    public ResponseEntity<Void> registerNickname(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody NicknameRegisterRequest dto){
         // body
         nicknameRegisterService.registerNickname(authId, dto.getNickname());
         return ResponseEntity.ok().build();
     }
 
     @PatchMapping("/profile/nickname")
-    public ResponseEntity<Void> registerProfileNickname(@RequestHeader("AUTH-ID") String authId, @RequestBody NicknameRegisterRequest dto){
+    public ResponseEntity<Void> registerProfileNickname(@RequestHeader("X-AUTH-ID") String authId, @RequestBody NicknameRegisterRequest dto){
         // body
         nicknameRegisterService.registerNickname(authId, dto.getNickname());
         return ResponseEntity.ok().build();

--- a/src/main/java/com/gaaji/auth/controller/ProfilePictureUploadController.java
+++ b/src/main/java/com/gaaji/auth/controller/ProfilePictureUploadController.java
@@ -1,0 +1,28 @@
+package com.gaaji.auth.controller;
+
+
+import com.gaaji.auth.applicationservice.ProfilePictureUploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RestController
+public class ProfilePictureUploadController {
+
+    private final ProfilePictureUploadService profilePictureUploadService;
+
+
+    @PostMapping("/auth/picture")
+    public ResponseEntity<Void> uploadProfilePicture(@RequestPart("file")MultipartFile multipartFile,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authId){
+        profilePictureUploadService.uploadPicture(multipartFile,authId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/gaaji/auth/controller/dto/RetrieveResponse.java
+++ b/src/main/java/com/gaaji/auth/controller/dto/RetrieveResponse.java
@@ -12,11 +12,12 @@ public class RetrieveResponse {
 
     private String authId;
     private String nickname;
+    private String pictureUrl;
     private double mannerTemperature;
 
 
-    public static RetrieveResponse of(String authId, String nickname, double mannerTemperature) {
-        return new RetrieveResponse(authId, validateNickname(nickname), mannerTemperature);
+    public static RetrieveResponse of(String authId, String nickname, double mannerTemperature, String url) {
+        return new RetrieveResponse(authId, validateNickname(nickname), url, mannerTemperature);
     }
 
     private static String validateNickname(String nickname){

--- a/src/main/java/com/gaaji/auth/domain/Auth.java
+++ b/src/main/java/com/gaaji/auth/domain/Auth.java
@@ -15,6 +15,7 @@ public class Auth {
     private AuthId id;
 
     private String nickname;
+    private String profilePictureUrl;
 
     @Embedded
     private PlatformInfo platformInfo;
@@ -42,6 +43,9 @@ public class Auth {
     }
     public void registerNickname(String nickname){
         this.nickname = nickname;
+    }
+    public void registerProfilePicture(String profilePictureUrl){
+        this.profilePictureUrl = profilePictureUrl;
     }
     public String getAuthIdForToken(){
         return id.getId();

--- a/src/main/java/com/gaaji/auth/domain/Auth.java
+++ b/src/main/java/com/gaaji/auth/domain/Auth.java
@@ -56,4 +56,8 @@ public class Auth {
     public double getMannerTemperature(){
         return mannerTemperature.getTemperature();
     }
+
+    public String getProfilePictureUrl() {
+        return this.profilePictureUrl;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
         - "oauth"
   application:
     name: auth-service
+  config:
+    import: secret.yml
 
 eureka:
   client:


### PR DESCRIPTION
# GM-78 프로필 사진 업로드 기능 추가
## Description
> 회원 정보에 프로필 사진을 등록하는 기능을 추가한다.
> 전송한 사진은 S3에 등록을 하고 DB에는 해당 사진의 URL을 저장한다.

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [X] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM-87 중고거래 글 조회
- GM-171 중고거래 글 조회 시 프로필 사진 URL 전달받

## Issues
프로필 사진을 추가하는 기능을 등록하고, 회원 정보 조회 API 사용 시 프로필 사진 URL도 추가로 반환하도록 설정함.
#### 프로필 사진 업로드
![image](https://user-images.githubusercontent.com/76154390/215678403-9a874caf-3485-4ec2-aa35-6c54cc81ec87.png)

#### 업로드 성공
![image](https://user-images.githubusercontent.com/76154390/215678465-c38e749c-1cf5-4cdd-96d3-c80ad2ea762a.png)



#### 회원 정보 조회
![image](https://user-images.githubusercontent.com/76154390/215678309-0419314f-1ece-4c83-8c1c-8f2ea6ac7c28.png)


## Related Files
- `Auth`
- `S3Uploader`
- `S3Config`
- `ProfilePictureUploadController`
- `ProfilePictureUploadService`

## Think About..  
얼마 걸리지 않는 쉬운 기능인데 어쩌다가 이렇게 늦게 시작했는지..
Auth랑 Town쪽 테스트 코드 언능 추가해야겠다.

## Conclusion  
> 프로필 사진은 가지다.
