### PR TITLE
GM-192 회원 서비스 예외처리

### DIFF
--- a/src/main/java/com/gaaji/auth/applicationservice/AuthRetrieveServiceImpl.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/AuthRetrieveServiceImpl.java
@@ -3,6 +3,7 @@ package com.gaaji.auth.applicationservice;
 import com.gaaji.auth.controller.dto.RetrieveResponse;
 import com.gaaji.auth.domain.Auth;
 import com.gaaji.auth.domain.AuthId;
+import com.gaaji.auth.exception.AuthIdNotFoundException;
 import com.gaaji.auth.repository.AuthRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,7 +20,7 @@ public class AuthRetrieveServiceImpl implements
     @Override
     public RetrieveResponse retrieveAuth(String authId) {
         Auth auth = authRepository.findById(authId)
-                .orElseThrow();
+                .orElseThrow(AuthIdNotFoundException::new);
         return RetrieveResponse.of(authId, auth.getNickname(), auth.getMannerTemperature(), auth.getProfilePictureUrl());
     }
 }

--- a/src/main/java/com/gaaji/auth/applicationservice/TokenServiceImpl.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/TokenServiceImpl.java
@@ -1,6 +1,7 @@
 package com.gaaji.auth.applicationservice;
 
 import com.gaaji.auth.controller.dto.TokenResponse;
+import com.gaaji.auth.exception.AuthIdNotFoundException;
 import com.gaaji.auth.jwt.JwtProvider;
 import com.gaaji.auth.repository.AuthRepository;
 import io.jsonwebtoken.Claims;
@@ -36,7 +37,8 @@ public class TokenServiceImpl implements TokenService{
         ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
         String authId = ops.get(refreshToken);
 
-        authRepository.findById(authId);
+        authRepository.findById(authId)
+                .orElseThrow(AuthIdNotFoundException::new);
         return jwtProvider.createAccessToken(authId);
     }
 


### PR DESCRIPTION
# GM-192 회원 서비스 예외처리
## Description
> 회원 ID를 조회할 때 존재하지 않을 경우에 예외 클래스를 발생하도록 설정함. 

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- X

## Issues
회원 아이디를 통해 회원을 조회할 때, 회원이 존재하지 않은 경우엔 미리 정의한 예외 클래스를 발생하도록 하였다.
이를 통해 타 서비스와의 통신에서 예외 상황을 파악하기 쉬울 것이다.

## Related Files
- `AuthRetrieveServiceImpl`
- `TokenServiceImpl`


## Conclusion  
> 다른 곳을 봐야 할듯
