### PR TITLE
Gm 257

### DIFF
--- a/src/main/java/com/gaaji/auth/applicationservice/ReviewCreateServiceImpl.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/ReviewCreateServiceImpl.java
@@ -19,6 +19,7 @@ import com.gaaji.auth.domain.ReviewId;
 import com.gaaji.auth.exception.EqualsSellerAndPurchaserException;
 import com.gaaji.auth.exception.NoMatchIdException;
 import com.gaaji.auth.exception.NoReviewException;
+import com.gaaji.auth.exception.NoTownException;
 import com.gaaji.auth.exception.NonexistentTargetException;
 import com.gaaji.auth.repository.ReviewRepository;
 
@@ -42,6 +43,10 @@ public class ReviewCreateServiceImpl implements ReviewCreateService {
 	}
 
 	private Review createReviewEntity(ReviewCreateRequest dto, MultipartFile multipartFile, String authId) {
+		if(dto.getTown() == null) {
+			throw new NoTownException();
+		}
+		
 		if((dto.getPurchaserId() == null) || dto.getSellerId() == null) {
 			throw new NonexistentTargetException();
 		} 
@@ -60,12 +65,12 @@ public class ReviewCreateServiceImpl implements ReviewCreateService {
 		if (dto.getPurchaserId().equals(authId)) {
 			return Review.of(ReviewId.of(this.reviewRepository.nextId()), PostId.of(dto.getPostId()), AuthId.of(authId),
 					AuthId.of(dto.getSellerId()), goodManners, badManners,
-					Comment.of(pictureUrl, dto.getContents(), true));
+					Comment.of(pictureUrl, dto.getContents(), dto.getTown(), true));
 			
 		} else if (dto.getSellerId().equals(authId)) {
 			return Review.of(ReviewId.of(this.reviewRepository.nextId()), PostId.of(dto.getPostId()), AuthId.of(authId),
 					AuthId.of(dto.getPurchaserId()), goodManners, badManners,
-					Comment.of(pictureUrl, dto.getContents(), false));
+					Comment.of(pictureUrl, dto.getContents(), dto.getTown(), false));
 		} else {
 			throw new NoMatchIdException();
 		}

--- a/src/main/java/com/gaaji/auth/applicationservice/ReviewRetriveService.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/ReviewRetriveService.java
@@ -1,9 +1,14 @@
 package com.gaaji.auth.applicationservice;
 
+import java.util.List;
+
+import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 
 public interface ReviewRetriveService {
 
 	ReviewRetrieveResponse retriveMyReview(String authId, String postId);
+
+	List<CommentRetrieveResponse> retriveComment(String authId);
 
 }

--- a/src/main/java/com/gaaji/auth/applicationservice/ReviewRetriveServiceImpl.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/ReviewRetriveServiceImpl.java
@@ -1,13 +1,20 @@
 package com.gaaji.auth.applicationservice;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
+import com.gaaji.auth.domain.Auth;
 import com.gaaji.auth.domain.AuthId;
 import com.gaaji.auth.domain.PostId;
 import com.gaaji.auth.domain.Review;
 import com.gaaji.auth.exception.NoSearchReviewException;
+import com.gaaji.auth.repository.AuthRepository;
 import com.gaaji.auth.repository.ReviewRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -18,11 +25,29 @@ import lombok.RequiredArgsConstructor;
 public class ReviewRetriveServiceImpl implements ReviewRetriveService{
 	
 	private final ReviewRepository reviewRepository;
+	private final AuthRepository authRepository;
 
 	@Override
 	public ReviewRetrieveResponse retriveMyReview(String authId, String postId) {
 		Review review = this.reviewRepository.findByPostIdAndSenderId(PostId.of(postId), AuthId.of(authId)).orElseThrow(NoSearchReviewException::new);
 		return ReviewRetrieveResponse.of(review.getReviewId().getId(), review.getComment().getContents(), review.getComment().getPictureUrl(), review.getGoodManners(), review.getBadManners());
+	}
+
+	@Override
+	public List<CommentRetrieveResponse> retriveComment(String authId) {
+		List<Review> reviewList = this.reviewRepository.findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId.of(authId));
+		List<CommentRetrieveResponse> commentList = new ArrayList<CommentRetrieveResponse>();
+		for(Review review : reviewList) {
+			
+			Auth auth = this.authRepository.findById(review.getSenderId().getId()).orElse(Auth.signUp(null, null, null));
+			if(auth.getAuthIdForToken()==null) {
+			auth.registerNickname(null);
+			}
+			commentList.add(CommentRetrieveResponse.of(review.getSenderId().getId(), auth.getNickname(), auth.getProfilePictureUrl(), review.getComment().getTown(), review.getComment().getContents(), review.getComment().getPictureUrl(), review.getComment().isIspurchaser(), review.getComment().getCreatedAt()));
+			
+		}
+		
+		return commentList;
 	}
 
 	

--- a/src/main/java/com/gaaji/auth/controller/ReviewRetriveController.java
+++ b/src/main/java/com/gaaji/auth/controller/ReviewRetriveController.java
@@ -1,5 +1,7 @@
 package com.gaaji.auth.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.gaaji.auth.applicationservice.ReviewRetriveService;
+import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 import com.gaaji.auth.domain.Review;
 
@@ -22,8 +25,15 @@ public class ReviewRetriveController {
 	private final ReviewRetriveService reviewRetriveService;
 	
 	@GetMapping("/my")
-	private ResponseEntity<ReviewRetrieveResponse> createReview(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String postId) {
+	private ResponseEntity<ReviewRetrieveResponse> retriveMyReview(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String postId) {
 		ReviewRetrieveResponse dto = this.reviewRetriveService.retriveMyReview(authId, postId);
 		return ResponseEntity.ok(dto);
 		}
+	
+	@GetMapping("/comment")
+	private ResponseEntity<List<CommentRetrieveResponse>> retriveComments(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String postId) {
+		List<CommentRetrieveResponse> dto = this.reviewRetriveService.retriveComment(authId);
+		return ResponseEntity.ok(dto);
+		}
+	
 }

--- a/src/main/java/com/gaaji/auth/controller/dto/CommentRetrieveResponse.java
+++ b/src/main/java/com/gaaji/auth/controller/dto/CommentRetrieveResponse.java
@@ -1,0 +1,28 @@
+package com.gaaji.auth.controller.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class CommentRetrieveResponse {
+
+	private String senderId;
+	private String nickname;
+    private String profilePictureUrl;
+	private String town;
+    private String contents;
+    private String pictureUrl;
+    private boolean ispurchaser;
+	private LocalDateTime createdAt;
+	
+	public static CommentRetrieveResponse of(String senderId, String nickname, String profilePictureUrl, String town, String contents, String pictureUrl, boolean ispurchaser, LocalDateTime createdAt) {
+		return new CommentRetrieveResponse(senderId, nickname, profilePictureUrl, town, contents, pictureUrl, ispurchaser, createdAt);
+	}
+	
+}

--- a/src/main/java/com/gaaji/auth/controller/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/gaaji/auth/controller/dto/ReviewCreateRequest.java
@@ -17,6 +17,7 @@ public class ReviewCreateRequest {
 	private String postId;
 	private String sellerId;
 	private String purchaserId;
+	private String town;
 	private List<String> goodManners;
 	private List<String> badManners;
 	private String contents;

--- a/src/main/java/com/gaaji/auth/domain/Comment.java
+++ b/src/main/java/com/gaaji/auth/domain/Comment.java
@@ -15,18 +15,20 @@ public class Comment {
 
 	private String pictureUrl;
 	private String contents;
+	private String town;
 	private boolean ispurchaser;
 	private LocalDateTime createdAt;
 
-	public Comment(String pictureUrl, String contents, boolean ispurchaser) {
+	public Comment(String pictureUrl, String contents, String town, boolean ispurchaser) {
 		this.pictureUrl = pictureUrl;
 		this.contents = contents;
 		this.ispurchaser = ispurchaser;
+		this.town = town;
 		this.createdAt = LocalDateTime.now();
 	}
 
-	public static Comment of(String pictureUrl, String contents, boolean ispurchaser) {
-		return new Comment(pictureUrl, contents, ispurchaser);
+	public static Comment of(String pictureUrl, String contents, String town, boolean ispurchaser) {
+		return new Comment(pictureUrl, contents, town, ispurchaser);
 
 	}
 

--- a/src/main/java/com/gaaji/auth/domain/Review.java
+++ b/src/main/java/com/gaaji/auth/domain/Review.java
@@ -62,7 +62,7 @@ public class Review {
 	public void modify(String pictureUrl, List<GoodManner> goodManners, List<BadManner> badManners, String contents) {
 		this.goodManners = goodManners;
 		this.badManners = badManners;
-		this.comment = Comment.of(pictureUrl, contents, this.comment.isIspurchaser());
+		this.comment = Comment.of(pictureUrl, contents, this.comment.getTown(), this.comment.isIspurchaser());
 	}
 
 	

--- a/src/main/java/com/gaaji/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/gaaji/auth/exception/AuthErrorCode.java
@@ -18,6 +18,7 @@ public enum AuthErrorCode implements ErrorCode{
     Equals_Seller_And_Purchaser(HttpStatus.BAD_REQUEST, "r-0006","판매자와 구매자가 동일합니다."),
     No_Search_Review(HttpStatus.BAD_REQUEST, "r-0007","해당 후기를 찾지 못했습니다."),
     No_Match_Sender(HttpStatus.BAD_REQUEST, "r-0008","해당 후기 작성자와 정보가 맞지 않습니다."),
+    No_Town(HttpStatus.BAD_REQUEST, "r-0009","해당 지역을 알 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/gaaji/auth/exception/NoTownException.java
+++ b/src/main/java/com/gaaji/auth/exception/NoTownException.java
@@ -1,0 +1,11 @@
+package com.gaaji.auth.exception;
+
+import static com.gaaji.auth.exception.AuthErrorCode.No_Town;
+
+public class NoTownException extends AbstractApiException {
+
+	public NoTownException() {
+		super(No_Town);
+	}
+
+}

--- a/src/main/java/com/gaaji/auth/repository/JpaReviewRepository.java
+++ b/src/main/java/com/gaaji/auth/repository/JpaReviewRepository.java
@@ -1,5 +1,6 @@
 package com.gaaji.auth.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,5 +13,7 @@ import com.gaaji.auth.domain.ReviewId;
 public interface JpaReviewRepository extends JpaRepository<Review, ReviewId>{
 
 	Optional<Review> findByPostIdAndSenderId(PostId postId, AuthId senderId);
+
+	List<Review> findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId receiverId);
 
 }

--- a/src/main/java/com/gaaji/auth/repository/ReviewRepository.java
+++ b/src/main/java/com/gaaji/auth/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.gaaji.auth.repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -19,5 +20,7 @@ public interface ReviewRepository {
 	Optional<Review> findById(ReviewId of);
 
 	Optional<Review> findByPostIdAndSenderId(PostId postId, AuthId senderId);
+
+	List<Review> findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId receiverId);
 
 }

--- a/src/main/java/com/gaaji/auth/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/gaaji/auth/repository/ReviewRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.gaaji.auth.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -30,6 +31,11 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 	@Override
 	public Optional<Review> findByPostIdAndSenderId(PostId postId, AuthId senderId) {
 		return this.jpaReviewRepository.findByPostIdAndSenderId(postId, senderId);
+	}
+
+	@Override
+	public List<Review> findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId receiverId) {
+		return this.jpaReviewRepository.findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(receiverId);
 	}
 
 }

--- a/src/test/java/com/gaaji/auth/repository/ReviewCreateJpaTest.java
+++ b/src/test/java/com/gaaji/auth/repository/ReviewCreateJpaTest.java
@@ -36,7 +36,7 @@ public class ReviewCreateJpaTest {
 		good.add(GoodManner.gm1);
 		List<BadManner> bad = new ArrayList<BadManner>();
 		bad.add(BadManner.bm2);
-		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", true));
+		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
 		
 		this.jpaReviewRepository.save(review);
 		
@@ -51,6 +51,7 @@ public class ReviewCreateJpaTest {
 		
 		assertThat(newReview.getComment().getPictureUrl()).isEqualTo("사진");
 		assertThat(newReview.getComment().getContents()).isEqualTo("내용");
+		assertThat(newReview.getComment().getTown()).isEqualTo("남가좌동");
 		assertThat(newReview.getComment().isIspurchaser()).isEqualTo(true);
 		
 	}

--- a/src/test/java/com/gaaji/auth/repository/ReviewRetriveJpaTest.java
+++ b/src/test/java/com/gaaji/auth/repository/ReviewRetriveJpaTest.java
@@ -37,7 +37,7 @@ public class ReviewRetriveJpaTest {
 		good.add(GoodManner.gm1);
 		List<BadManner> bad = new ArrayList<BadManner>();
 		bad.add(BadManner.bm2);
-		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", true));
+		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
 		
 		this.jpaReviewRepository.save(review);
 		
@@ -52,6 +52,7 @@ public class ReviewRetriveJpaTest {
 		
 		assertThat(newReview.getComment().getPictureUrl()).isEqualTo("사진");
 		assertThat(newReview.getComment().getContents()).isEqualTo("내용");
+		assertThat(newReview.getComment().getTown()).isEqualTo("남가좌동");
 		assertThat(newReview.getComment().isIspurchaser()).isEqualTo(true);
 		
 	}

--- a/src/test/java/com/gaaji/auth/repository/ReviewRetriveJpaTest.java
+++ b/src/test/java/com/gaaji/auth/repository/ReviewRetriveJpaTest.java
@@ -32,7 +32,7 @@ public class ReviewRetriveJpaTest {
 	}
 	
 	@Test
-	void 조회테스트() {
+	void 내조회테스트() {
 		List<GoodManner> good = new ArrayList<GoodManner>();
 		good.add(GoodManner.gm1);
 		List<BadManner> bad = new ArrayList<BadManner>();
@@ -42,6 +42,37 @@ public class ReviewRetriveJpaTest {
 		this.jpaReviewRepository.save(review);
 		
 		Review newReview = this.jpaReviewRepository.findByPostIdAndSenderId(PostId.of("post"), AuthId.of("sender")).orElseThrow(NoSearchReviewException::new);
+		assertThat(newReview.getReviewId().getId()).isEqualTo("review");
+		assertThat(newReview.getPostId().getId()).isEqualTo("post");
+		
+		assertThat(newReview.getSenderId().getId()).isEqualTo("sender");
+		assertThat(newReview.getReceiverId().getId()).isEqualTo("receiver");
+		assertThat(newReview.getGoodManners().get(0)).isEqualTo(GoodManner.gm1);
+		assertThat(newReview.getBadManners().get(0)).isEqualTo(BadManner.bm2);
+		
+		assertThat(newReview.getComment().getPictureUrl()).isEqualTo("사진");
+		assertThat(newReview.getComment().getContents()).isEqualTo("내용");
+		assertThat(newReview.getComment().getTown()).isEqualTo("남가좌동");
+		assertThat(newReview.getComment().isIspurchaser()).isEqualTo(true);
+		
+	}
+	
+	@Test
+	void 후기조회테스트() {
+		List<GoodManner> good = new ArrayList<GoodManner>();
+		good.add(GoodManner.gm1);
+		List<BadManner> bad = new ArrayList<BadManner>();
+		bad.add(BadManner.bm2);
+		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
+		Review review1 = Review.of(ReviewId.of("review1"), PostId.of("post1"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", null, "남가좌동", true));
+
+		this.jpaReviewRepository.save(review);
+		this.jpaReviewRepository.save(review1);
+		
+		List<Review> reviewList = this.jpaReviewRepository.findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId.of("receiver"));
+		
+		assertThat(reviewList.size()).isEqualTo(1);
+		Review newReview = reviewList.get(0);
 		assertThat(newReview.getReviewId().getId()).isEqualTo("review");
 		assertThat(newReview.getPostId().getId()).isEqualTo("post");
 		

--- a/src/test/java/com/gaaji/auth/service/ReviewCreateServiceTest.java
+++ b/src/test/java/com/gaaji/auth/service/ReviewCreateServiceTest.java
@@ -25,6 +25,7 @@ import com.gaaji.auth.exception.EqualsSellerAndPurchaserException;
 import com.gaaji.auth.exception.NoMatchIdException;
 import com.gaaji.auth.exception.NoReviewException;
 import com.gaaji.auth.exception.NoSearchReviewException;
+import com.gaaji.auth.exception.NoTownException;
 import com.gaaji.auth.exception.NonexistentTargetException;
 import com.gaaji.auth.repository.JpaReviewRepository;
 
@@ -53,8 +54,8 @@ public class ReviewCreateServiceTest {
 		bad.add("bm3");
 		bad.add("bm4");
 		
-		 ReviewCreateRequest dto1 = new ReviewCreateRequest("post", "aaa", "purchaser", no, no, "빨라요");
-		 ReviewCreateRequest dto2 = new ReviewCreateRequest("post1", "seller", "aaa", good, bad, null);
+		 ReviewCreateRequest dto1 = new ReviewCreateRequest("post", "aaa", "purchaser", "남가좌동", no, no, "빨라요");
+		 ReviewCreateRequest dto2 = new ReviewCreateRequest("post1", "seller", "aaa", "남가좌동", good, bad, null);
 		 
 		 
 		 reviewCreateService.createReview("aaa", null, dto1);
@@ -72,6 +73,7 @@ public class ReviewCreateServiceTest {
 			
 			assertThat(newReview.getComment().getPictureUrl()).isEqualTo(null);
 			assertThat(newReview.getComment().getContents()).isEqualTo("빨라요");
+			assertThat(newReview.getComment().getTown()).isEqualTo("남가좌동");
 			assertThat(newReview.getComment().isIspurchaser()).isEqualTo(false);
 		 
 			 Review newReview1 = this.jpaReviewRepository.findByPostIdAndSenderId(PostId.of("post1"), AuthId.of("aaa")).orElseThrow(NoSearchReviewException::new);
@@ -85,20 +87,28 @@ public class ReviewCreateServiceTest {
 			assertThat(newReview1.getBadManners().get(1)).isEqualTo(BadManner.bm4);		
 			assertThat(newReview1.getComment().getPictureUrl()).isEqualTo(null);
 			assertThat(newReview1.getComment().getContents()).isEqualTo(null);
+			assertThat(newReview.getComment().getTown()).isEqualTo("남가좌동");
 			assertThat(newReview1.getComment().isIspurchaser()).isEqualTo(true);
+	}
+	
+	@Test
+	void 추가서비스에러케이스5타운이없는경우 (){
+		List<String> no = new ArrayList<String>();
+		 ReviewCreateRequest dto = new ReviewCreateRequest("post", "purchaser", "purchaser", null, no, no, "123");
+		 assertThatThrownBy(()->reviewCreateService.createReview("aaa", null, dto)).isInstanceOf(NoTownException.class);
 	}
 	
 	@Test
 	void 추가서비스에러케이스4판매자와구매자가같은경우 (){
 		List<String> no = new ArrayList<String>();
-		 ReviewCreateRequest dto = new ReviewCreateRequest("post", "purchaser", "purchaser", no, no, "123");
+		 ReviewCreateRequest dto = new ReviewCreateRequest("post", "purchaser", "purchaser", "남가좌동", no, no, "123");
 		 assertThatThrownBy(()->reviewCreateService.createReview("aaa", null, dto)).isInstanceOf(EqualsSellerAndPurchaserException.class);
 	}
 	
 	@Test
 	void 추가서비스에러케이스3후기작성자가구매자와판매자가아닌경우 (){
 		List<String> no = new ArrayList<String>();
-		ReviewCreateRequest dto = new ReviewCreateRequest("post", "seller", "purchaser", no, no, "123");
+		ReviewCreateRequest dto = new ReviewCreateRequest("post", "seller", "purchaser", "남가좌동", no, no, "123");
 
 		 assertThatThrownBy(()->reviewCreateService.createReview("aaa", null, dto)).isInstanceOf(NoMatchIdException.class);
 	}
@@ -106,7 +116,7 @@ public class ReviewCreateServiceTest {
 	@Test
 	void 추가서비스에러케이스2후기가없는경우 (){
 		List<String> no = new ArrayList<String>();
-		 ReviewCreateRequest dto = new ReviewCreateRequest("post", "aaa", "purchaser", no, no, null);
+		 ReviewCreateRequest dto = new ReviewCreateRequest("post", "aaa", "purchaser", "남가좌동", no, no, null);
 
 		 assertThatThrownBy(()->reviewCreateService.createReview("aaa", null, dto)).isInstanceOf(NoReviewException.class);
 	}
@@ -114,7 +124,7 @@ public class ReviewCreateServiceTest {
 	@Test
 	void 추가서비스에러케이스1글과관련된아이디없는경우 (){
 		List<String> no = new ArrayList<String>();
-		 ReviewCreateRequest dto = new ReviewCreateRequest("aaa", null, null, no, no, "123");
+		 ReviewCreateRequest dto = new ReviewCreateRequest("aaa", null, null, "남가좌동", no, no, "123");
 
 		 assertThatThrownBy(()->reviewCreateService.createReview("aaa", null, dto)).isInstanceOf(NonexistentTargetException.class);
 	}

--- a/src/test/java/com/gaaji/auth/service/ReviewRetriveServiceTest.java
+++ b/src/test/java/com/gaaji/auth/service/ReviewRetriveServiceTest.java
@@ -14,18 +14,22 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.gaaji.auth.applicationservice.ReviewRetriveService;
 import com.gaaji.auth.applicationservice.ReviewUpdateService;
+import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewUpdateRequest;
+import com.gaaji.auth.domain.Auth;
 import com.gaaji.auth.domain.AuthId;
 import com.gaaji.auth.domain.BadManner;
 import com.gaaji.auth.domain.Comment;
 import com.gaaji.auth.domain.GoodManner;
+import com.gaaji.auth.domain.PlatformType;
 import com.gaaji.auth.domain.PostId;
 import com.gaaji.auth.domain.Review;
 import com.gaaji.auth.domain.ReviewId;
 import com.gaaji.auth.exception.EqualsSellerAndPurchaserException;
 import com.gaaji.auth.exception.NoMatchSenderException;
 import com.gaaji.auth.exception.NoSearchReviewException;
+import com.gaaji.auth.repository.JpaAuthRepository;
 import com.gaaji.auth.repository.JpaReviewRepository;
 
 @Transactional
@@ -38,13 +42,16 @@ public class ReviewRetriveServiceTest {
 	@Autowired
 	JpaReviewRepository jpaReviewRepository;
 	
+	@Autowired
+	JpaAuthRepository jpaAuthRepository;
+	
 	@AfterEach
 	void afterEach() {
 		this.jpaReviewRepository.deleteAll();
 	}
 	
 	@Test
-	void 조회서비스 (){
+	void 내조회서비스 (){
 	List<GoodManner> good = new ArrayList<GoodManner>();
 	good.add(GoodManner.gm1);
 	List<BadManner> bad = new ArrayList<BadManner>();
@@ -61,10 +68,7 @@ public class ReviewRetriveServiceTest {
 		assertThat(newReview.getPictureUrl()).isEqualTo("사진");
 		assertThat(newReview.getGoodManners().get(0)).isEqualTo(GoodManner.gm1);
 		assertThat(newReview.getBadManners().get(0)).isEqualTo(BadManner.bm2);
-		
-		
 
-	
 	}
 	
 	@Test
@@ -74,5 +78,45 @@ public class ReviewRetriveServiceTest {
 
 	}
 
+	@Test
+	void 후기조회서비스 (){
+	List<GoodManner> good = new ArrayList<GoodManner>();
+	good.add(GoodManner.gm1);
+	List<BadManner> bad = new ArrayList<BadManner>();
+	bad.add(BadManner.bm2);
+	Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
+	this.jpaReviewRepository.save(review);
+	Review review1 = Review.of(ReviewId.of("review1"), PostId.of("post1"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", null, "남가좌동", true));
+	this.jpaReviewRepository.save(review1);
+	Review review2 = Review.of(ReviewId.of("review2"), PostId.of("post2"), AuthId.of("sender1"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용1", "남가좌동", false));
+	this.jpaReviewRepository.save(review2);
+	jpaAuthRepository.save(Auth.signUp("sender", PlatformType.NAVER, "test@naver.com"));
+	
+	
+	
+	
+	
+	List<CommentRetrieveResponse> reviewList = this.reviewRetriveService.retriveComment("receiver");
+	assertThat(reviewList.size()).isEqualTo(2);
+	CommentRetrieveResponse newReview1 = reviewList.get(0);
+	assertThat(newReview1.getSenderId()).isEqualTo("sender1");
+	assertThat(newReview1.getNickname()).isEqualTo(null);
+	assertThat(newReview1.getProfilePictureUrl()).isEqualTo(null);
+	assertThat(newReview1.getTown()).isEqualTo("남가좌동");
+	assertThat(newReview1.getContents()).isEqualTo("내용1");
+	assertThat(newReview1.getPictureUrl()).isEqualTo("사진");
+	assertThat(newReview1.isIspurchaser()).isEqualTo(false);
+
+	
+	CommentRetrieveResponse newReview = reviewList.get(1);
+	assertThat(newReview.getSenderId()).isEqualTo("sender");
+	assertThat(newReview.getNickname()).isEqualTo("익명");
+	assertThat(newReview.getProfilePictureUrl()).isEqualTo(null);
+	assertThat(newReview.getTown()).isEqualTo("남가좌동");
+	assertThat(newReview.getContents()).isEqualTo("내용");
+	assertThat(newReview.getPictureUrl()).isEqualTo("사진");
+	assertThat(newReview.isIspurchaser()).isEqualTo(true);
+
+	}
 	
 }

--- a/src/test/java/com/gaaji/auth/service/ReviewRetriveServiceTest.java
+++ b/src/test/java/com/gaaji/auth/service/ReviewRetriveServiceTest.java
@@ -49,7 +49,7 @@ public class ReviewRetriveServiceTest {
 	good.add(GoodManner.gm1);
 	List<BadManner> bad = new ArrayList<BadManner>();
 	bad.add(BadManner.bm2);
-	Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", true));
+	Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
 	
 	this.jpaReviewRepository.save(review);
 	

--- a/src/test/java/com/gaaji/auth/service/ReviewUpdateServiceTest.java
+++ b/src/test/java/com/gaaji/auth/service/ReviewUpdateServiceTest.java
@@ -47,7 +47,7 @@ public class ReviewUpdateServiceTest {
 	good.add(GoodManner.gm1);
 	List<BadManner> bad = new ArrayList<BadManner>();
 	bad.add(BadManner.bm2);
-	Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", true));
+	Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
 	
 	this.jpaReviewRepository.save(review);
 	
@@ -74,6 +74,7 @@ public class ReviewUpdateServiceTest {
 		
 		assertThat(newReview.getComment().getPictureUrl()).isEqualTo("사진");
 		assertThat(newReview.getComment().getContents()).isEqualTo("수정");
+		assertThat(newReview.getComment().getTown()).isEqualTo("남가좌동");
 		assertThat(newReview.getComment().isIspurchaser()).isEqualTo(true);
 	
 	}
@@ -84,7 +85,7 @@ public class ReviewUpdateServiceTest {
 		good.add(GoodManner.gm1);
 		List<BadManner> bad = new ArrayList<BadManner>();
 		bad.add(BadManner.bm2);
-		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", true));
+		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
 		
 		this.jpaReviewRepository.save(review);
 
@@ -104,7 +105,7 @@ public class ReviewUpdateServiceTest {
 		good.add(GoodManner.gm1);
 		List<BadManner> bad = new ArrayList<BadManner>();
 		bad.add(BadManner.bm2);
-		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", true));
+		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
 		
 		this.jpaReviewRepository.save(review);
 		


### PR DESCRIPTION
# Issue# - Issue
## Description
> Gm 257 후기 조회

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- Town
후기만 가져오는 것이 아니라 해당 후기를 작성한 사람의 정보도 가져와서 리턴을 받아야 했다.
이 때, 타운의 경우 다른 서비스이기 때문에 호출할 때마다 타운을 호출해야해서 해당 후기의 타운 정보를 도메인에 같이 저장하는 형태로 바꿨다

## Issues
<img width="779" alt="image" src="https://user-images.githubusercontent.com/48744386/220543959-1bf6abcb-7c17-4443-9cdb-185dad59dbb7.png">
후기를 부를 때 auth에서 유저 정보를 가져오는 과정에서는 유저가 탈퇴를 해서 없는 경우가 생길 수도 있는데 문제가 생길 수도 있으니 일단 탈퇴한 유저의 Id는 가지고 있고 나머지는 null로 리턴을 받는 형식을 택했다.
### Test
  
*** 

## Related Files
- ReviewRetriveService
- ReviewRetriveController

## Think About..  
탈퇴한 맴버의 정보는 특정 기간은 보관하고 그 이후에는 일괄 삭제하는 방식을 생각해봐야 할 것 같다.

## Conclusion  
> 후기 조회 끝
