### PR TITLE
Gm 255

### DIFF
--- a/src/main/java/com/gaaji/auth/applicationservice/ReviewRetriveService.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/ReviewRetriveService.java
@@ -3,6 +3,7 @@ package com.gaaji.auth.applicationservice;
 import java.util.List;
 
 import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
+import com.gaaji.auth.controller.dto.MannerRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 
 public interface ReviewRetriveService {
@@ -10,5 +11,7 @@ public interface ReviewRetriveService {
 	ReviewRetrieveResponse retriveMyReview(String authId, String postId);
 
 	List<CommentRetrieveResponse> retriveComment(String authId);
+
+	MannerRetrieveResponse retriveManner(String authId, String userId);
 
 }

--- a/src/main/java/com/gaaji/auth/controller/ReviewRetriveController.java
+++ b/src/main/java/com/gaaji/auth/controller/ReviewRetriveController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.gaaji.auth.applicationservice.ReviewRetriveService;
 import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
+import com.gaaji.auth.controller.dto.MannerRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 import com.gaaji.auth.domain.Review;
 
@@ -36,4 +37,9 @@ public class ReviewRetriveController {
 		return ResponseEntity.ok(dto);
 		}
 	
+	@GetMapping("/manner")
+	private ResponseEntity<MannerRetrieveResponse> retriveManner(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String userId) {
+		MannerRetrieveResponse dto = this.reviewRetriveService.retriveManner(authId, userId);
+		return ResponseEntity.ok(dto);
+		}
 }

--- a/src/main/java/com/gaaji/auth/controller/dto/BadMannerCount.java
+++ b/src/main/java/com/gaaji/auth/controller/dto/BadMannerCount.java
@@ -1,0 +1,20 @@
+package com.gaaji.auth.controller.dto;
+
+import com.gaaji.auth.domain.AuthId;
+import com.gaaji.auth.domain.BadManner;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class BadMannerCount {
+	private BadManner badManner;
+	private int count;
+	
+	public static BadMannerCount of(BadManner badManner, int counter) {
+		return new BadMannerCount(badManner, counter);
+	}
+}

--- a/src/main/java/com/gaaji/auth/controller/dto/GoodMannerCount.java
+++ b/src/main/java/com/gaaji/auth/controller/dto/GoodMannerCount.java
@@ -1,0 +1,24 @@
+package com.gaaji.auth.controller.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.gaaji.auth.domain.AuthId;
+import com.gaaji.auth.domain.GoodManner;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class GoodMannerCount {
+	private GoodManner goodManners;
+	private int count;
+	
+	public static GoodMannerCount of(GoodManner goodManners, int count) {
+		return new GoodMannerCount(goodManners, count);
+	}
+
+}

--- a/src/main/java/com/gaaji/auth/controller/dto/MannerRetrieveResponse.java
+++ b/src/main/java/com/gaaji/auth/controller/dto/MannerRetrieveResponse.java
@@ -1,0 +1,21 @@
+package com.gaaji.auth.controller.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class MannerRetrieveResponse {
+	private List<GoodMannerCount> goodMannerCount;
+	private List<BadMannerCount> badMannerCount;
+	
+
+	public static MannerRetrieveResponse of(List<GoodMannerCount> goodMannerCount,
+			List<BadMannerCount> badMannerCount) {
+		return new MannerRetrieveResponse(goodMannerCount, badMannerCount);
+	}
+}

--- a/src/main/java/com/gaaji/auth/domain/Review.java
+++ b/src/main/java/com/gaaji/auth/domain/Review.java
@@ -43,12 +43,12 @@ public class Review {
 	private AuthId receiverId;
 	
 	@ElementCollection
-    @CollectionTable(name = "goodManner", 
+    @CollectionTable(name = "goodManners", 
         joinColumns = @JoinColumn(name = "reviewId"))
     private List<GoodManner> goodManners;
 	
 	@ElementCollection
-    @CollectionTable(name = "badManner", 
+    @CollectionTable(name = "badManners", 
         joinColumns = @JoinColumn(name = "reviewId"))
     private List<BadManner> badManners;
 	

--- a/src/main/java/com/gaaji/auth/repository/JpaReviewRepository.java
+++ b/src/main/java/com/gaaji/auth/repository/JpaReviewRepository.java
@@ -4,8 +4,12 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.gaaji.auth.controller.dto.GoodMannerCount;
 import com.gaaji.auth.domain.AuthId;
+import com.gaaji.auth.domain.GoodManner;
 import com.gaaji.auth.domain.PostId;
 import com.gaaji.auth.domain.Review;
 import com.gaaji.auth.domain.ReviewId;
@@ -15,5 +19,11 @@ public interface JpaReviewRepository extends JpaRepository<Review, ReviewId>{
 	Optional<Review> findByPostIdAndSenderId(PostId postId, AuthId senderId);
 
 	List<Review> findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId receiverId);
+
+	List<Review> findByReceiverId(String receiverId);
+
+	List<Review> findDistinctByReceiverIdAndGoodMannersNotNull(AuthId receiverId);
+
+	List<Review> findDistinctByReceiverIdAndBadMannersNotNull(AuthId receiverId);
 
 }

--- a/src/main/java/com/gaaji/auth/repository/ReviewRepository.java
+++ b/src/main/java/com/gaaji/auth/repository/ReviewRepository.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.gaaji.auth.controller.dto.GoodMannerCount;
 import com.gaaji.auth.domain.AuthId;
+import com.gaaji.auth.domain.GoodManner;
 import com.gaaji.auth.domain.PostId;
 import com.gaaji.auth.domain.Review;
 import com.gaaji.auth.domain.ReviewId;
@@ -22,5 +24,11 @@ public interface ReviewRepository {
 	Optional<Review> findByPostIdAndSenderId(PostId postId, AuthId senderId);
 
 	List<Review> findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId receiverId);
+
+	List<Review> findByReceiverId(String receiverId);
+
+	List<Review> findDistinctByReceiverIdAndGoodMannersNotNull(AuthId receiverId);
+
+	List<Review> findDistinctByReceiverIdAndBadMannersNotNull(AuthId receiverId);
 
 }

--- a/src/main/java/com/gaaji/auth/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/gaaji/auth/repository/ReviewRepositoryImpl.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
+import com.gaaji.auth.controller.dto.GoodMannerCount;
 import com.gaaji.auth.domain.AuthId;
+import com.gaaji.auth.domain.GoodManner;
 import com.gaaji.auth.domain.PostId;
 import com.gaaji.auth.domain.Review;
 import com.gaaji.auth.domain.ReviewId;
@@ -37,5 +39,22 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 	public List<Review> findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId receiverId) {
 		return this.jpaReviewRepository.findByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(receiverId);
 	}
+
+	@Override
+	public List<Review> findByReceiverId(String receiverId) {
+		return this.jpaReviewRepository.findByReceiverId(receiverId);
+	}
+
+	@Override
+	public List<Review> findDistinctByReceiverIdAndGoodMannersNotNull(AuthId receiverId) {
+		return this.jpaReviewRepository.findDistinctByReceiverIdAndGoodMannersNotNull(receiverId);
+	}
+
+	@Override
+	public List<Review> findDistinctByReceiverIdAndBadMannersNotNull(AuthId receiverId) {
+		return this.jpaReviewRepository.findDistinctByReceiverIdAndBadMannersNotNull(receiverId);
+	}
+
+
 
 }

--- a/src/test/java/com/gaaji/auth/repository/ReviewRetriveJpaTest.java
+++ b/src/test/java/com/gaaji/auth/repository/ReviewRetriveJpaTest.java
@@ -87,5 +87,40 @@ public class ReviewRetriveJpaTest {
 		assertThat(newReview.getComment().isIspurchaser()).isEqualTo(true);
 		
 	}
+	
+	@Test
+	void 매너조회테스트() {
+		List<GoodManner> good = new ArrayList<GoodManner>();
+		good.add(GoodManner.gm1);
+		List<BadManner> bad = new ArrayList<BadManner>();
+		bad.add(BadManner.bm2);
+		
+		List<GoodManner> notGood = new ArrayList<GoodManner>();
+		List<BadManner> notBad = new ArrayList<BadManner>();
+		Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
+		Review review1 = Review.of(ReviewId.of("review1"), PostId.of("post1"), AuthId.of("sender"), AuthId.of("receiver"), notGood, notBad, Comment.of("사진", null, "남가좌동", true));
+
+		this.jpaReviewRepository.save(review);
+		this.jpaReviewRepository.save(review1);
+
+		List<Review> reviewList = this.jpaReviewRepository.findDistinctByReceiverIdAndGoodMannersNotNull(AuthId.of("receiver"));
+		
+		assertThat(reviewList.size()).isEqualTo(1);
+		Review newReview = reviewList.get(0);
+		assertThat(newReview.getReviewId().getId()).isEqualTo("review");
+		assertThat(newReview.getPostId().getId()).isEqualTo("post");
+		
+		assertThat(newReview.getSenderId().getId()).isEqualTo("sender");
+		assertThat(newReview.getReceiverId().getId()).isEqualTo("receiver");
+		assertThat(newReview.getGoodManners().get(0)).isEqualTo(GoodManner.gm1);
+		assertThat(newReview.getBadManners().get(0)).isEqualTo(BadManner.bm2);
+		
+		assertThat(newReview.getComment().getPictureUrl()).isEqualTo("사진");
+		assertThat(newReview.getComment().getContents()).isEqualTo("내용");
+		assertThat(newReview.getComment().getTown()).isEqualTo("남가좌동");
+		assertThat(newReview.getComment().isIspurchaser()).isEqualTo(true);
+		
+		
+	}
 
 }

--- a/src/test/java/com/gaaji/auth/service/ReviewRetriveServiceTest.java
+++ b/src/test/java/com/gaaji/auth/service/ReviewRetriveServiceTest.java
@@ -14,7 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.gaaji.auth.applicationservice.ReviewRetriveService;
 import com.gaaji.auth.applicationservice.ReviewUpdateService;
+import com.gaaji.auth.controller.dto.BadMannerCount;
 import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
+import com.gaaji.auth.controller.dto.GoodMannerCount;
+import com.gaaji.auth.controller.dto.MannerRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewUpdateRequest;
 import com.gaaji.auth.domain.Auth;
@@ -117,6 +120,54 @@ public class ReviewRetriveServiceTest {
 	assertThat(newReview.getPictureUrl()).isEqualTo("사진");
 	assertThat(newReview.isIspurchaser()).isEqualTo(true);
 
+	}
+	
+	@Test
+	void 매너조회서비스 (){
+	List<GoodManner> good = new ArrayList<GoodManner>();
+	good.add(GoodManner.gm1);
+	good.add(GoodManner.gm2);
+	
+	List<BadManner> bad = new ArrayList<BadManner>();
+	bad.add(BadManner.bm2);
+	bad.add(BadManner.bm5);
+	
+	List<GoodManner> good1 = new ArrayList<GoodManner>();
+	good1.add(GoodManner.gm1);
+	good1.add(GoodManner.gm3);
+	
+	List<BadManner> bad1 = new ArrayList<BadManner>();
+	bad1.add(BadManner.bm2);
+	bad1.add(BadManner.bm3);
+	bad1.add(BadManner.bm5);
+	
+	Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
+	Review review1 = Review.of(ReviewId.of("review1"), PostId.of("post1"), AuthId.of("sender"), AuthId.of("receiver"), good, bad1, Comment.of("사진", null, "남가좌동", true));
+	Review review2 = Review.of(ReviewId.of("review2"), PostId.of("post2"), AuthId.of("sender1"), AuthId.of("receiver"), good1, bad, Comment.of("사진", "내용1", "남가좌동", false));
+
+	this.jpaReviewRepository.save(review);
+	this.jpaReviewRepository.save(review1);
+	this.jpaReviewRepository.save(review2);		
+	
+
+	MannerRetrieveResponse reviewList = this.reviewRetriveService.retriveManner("receiver", "receiver");
+	
+	
+	List<GoodMannerCount> goodMannerCount = reviewList.getGoodMannerCount();
+	assertThat(goodMannerCount.get(0).getGoodManners()).isEqualTo(GoodManner.gm1);
+	assertThat(goodMannerCount.get(0).getCount()).isEqualTo(3);
+	assertThat(goodMannerCount.get(1).getGoodManners()).isEqualTo(GoodManner.gm2);
+	assertThat(goodMannerCount.get(1).getCount()).isEqualTo(2);
+	assertThat(goodMannerCount.get(2).getGoodManners()).isEqualTo(GoodManner.gm3);
+	assertThat(goodMannerCount.get(2).getCount()).isEqualTo(1);
+	
+	List<BadMannerCount> badMannerCount = reviewList.getBadMannerCount();
+	assertThat(badMannerCount.get(0).getBadManner()).isEqualTo(BadManner.bm2);
+	assertThat(badMannerCount.get(0).getCount()).isEqualTo(3);
+	assertThat(badMannerCount.get(1).getBadManner()).isEqualTo(BadManner.bm5);
+	assertThat(badMannerCount.get(1).getCount()).isEqualTo(3);
+	assertThat(badMannerCount.get(2).getBadManner()).isEqualTo(BadManner.bm3);
+	assertThat(badMannerCount.get(2).getCount()).isEqualTo(1);
 	}
 	
 }


### PR DESCRIPTION
# Issue# - Issue
## Description
> Gm 255 긍정 및 부정 매너평가 조회

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- Gm 251

## Issues
<img width="574" alt="image" src="https://user-images.githubusercontent.com/48744386/221508411-78c633d3-c85f-44c4-b9fa-f40f17e7a1ab.png">
당근마켓처럼 부정 평가는 해당 유저 본인일 경우에만 볼 수 있게 했다. 다른 유저가 내 매너온도를 조회하면 긍정 응답만 받는다
<img width="701" alt="image" src="https://user-images.githubusercontent.com/48744386/221508630-e17c27fc-ecc5-41dd-96fc-21e986809a7a.png">
긍정평가가 있는 후기를 조회한 후 개수를 세고 정렬을 해서 리턴을 한다

### Test
  <img width="790" alt="image" src="https://user-images.githubusercontent.com/48744386/221508901-0bb17220-19e8-4040-87ff-1de1341b6b01.png">
<img width="547" alt="image" src="https://user-images.githubusercontent.com/48744386/221508973-6b96cb47-622a-4c4d-bff4-466ccedce771.png">
<img width="285" alt="image" src="https://user-images.githubusercontent.com/48744386/221509014-eadf8669-e843-4e63-a42c-1fe9a096c176.png">


*** 테스트도 다양한 경우로 해보았고 정상 작동 했다.

## Related Files
- ReviewRetriveService
- ReviewRetriveController
- 
## Think About..  

## Conclusion  
> 매너평가 조회 완료
