### PR TITLE
Gm 253

### DIFF
--- a/src/main/java/com/gaaji/auth/applicationservice/ReviewRetriveService.java
+++ b/src/main/java/com/gaaji/auth/applicationservice/ReviewRetriveService.java
@@ -4,14 +4,17 @@ import java.util.List;
 
 import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
 import com.gaaji.auth.controller.dto.MannerRetrieveResponse;
+import com.gaaji.auth.controller.dto.PreviewReviewRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 
 public interface ReviewRetriveService {
 
 	ReviewRetrieveResponse retriveMyReview(String authId, String postId);
 
-	List<CommentRetrieveResponse> retriveComment(String authId);
+	List<CommentRetrieveResponse> retriveComment(String userId);
 
 	MannerRetrieveResponse retriveManner(String authId, String userId);
+
+	PreviewReviewRetrieveResponse retriveReview(String userId);
 
 }

--- a/src/main/java/com/gaaji/auth/controller/ReviewRetriveController.java
+++ b/src/main/java/com/gaaji/auth/controller/ReviewRetriveController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.gaaji.auth.applicationservice.ReviewRetriveService;
 import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
 import com.gaaji.auth.controller.dto.MannerRetrieveResponse;
+import com.gaaji.auth.controller.dto.PreviewReviewRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 import com.gaaji.auth.domain.Review;
 
@@ -32,14 +33,20 @@ public class ReviewRetriveController {
 		}
 	
 	@GetMapping("/comment")
-	private ResponseEntity<List<CommentRetrieveResponse>> retriveComments(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String postId) {
-		List<CommentRetrieveResponse> dto = this.reviewRetriveService.retriveComment(authId);
+	private ResponseEntity<List<CommentRetrieveResponse>> retriveComments(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String userId) {
+		List<CommentRetrieveResponse> dto = this.reviewRetriveService.retriveComment(userId);
 		return ResponseEntity.ok(dto);
 		}
 	
 	@GetMapping("/manner")
 	private ResponseEntity<MannerRetrieveResponse> retriveManner(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String userId) {
 		MannerRetrieveResponse dto = this.reviewRetriveService.retriveManner(authId, userId);
+		return ResponseEntity.ok(dto);
+		}
+	
+	@GetMapping
+	private ResponseEntity<PreviewReviewRetrieveResponse> retriveReview(@RequestHeader(HttpHeaders.AUTHORIZATION) String authId, @RequestBody String userId) {
+		PreviewReviewRetrieveResponse dto = this.reviewRetriveService.retriveReview(userId);
 		return ResponseEntity.ok(dto);
 		}
 }

--- a/src/main/java/com/gaaji/auth/controller/dto/CommentInfo.java
+++ b/src/main/java/com/gaaji/auth/controller/dto/CommentInfo.java
@@ -1,0 +1,27 @@
+package com.gaaji.auth.controller.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class CommentInfo {
+
+	private String senderId;
+	private String nickname;
+    private String profilePictureUrl;
+	private String town;
+    private String contents;
+    private String pictureUrl;
+    private boolean ispurchaser;
+	private LocalDateTime createdAt;
+	
+	public static CommentInfo of(String senderId, String nickname, String profilePictureUrl, String town, String contents, String pictureUrl, boolean ispurchaser, LocalDateTime createdAt) {
+		return new CommentInfo(senderId, nickname, profilePictureUrl, town, contents, pictureUrl, ispurchaser, createdAt);
+	}
+}

--- a/src/main/java/com/gaaji/auth/controller/dto/PreviewReviewRetrieveResponse.java
+++ b/src/main/java/com/gaaji/auth/controller/dto/PreviewReviewRetrieveResponse.java
@@ -1,0 +1,23 @@
+package com.gaaji.auth.controller.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor
+public class PreviewReviewRetrieveResponse {
+
+	private List<CommentInfo> commentInfo;
+	private List<GoodMannerCount> goodMannerCount;
+	
+	public static PreviewReviewRetrieveResponse of(List<CommentInfo> commentInfo,
+			List<GoodMannerCount> goodMannerCount) {
+		return new PreviewReviewRetrieveResponse(commentInfo, goodMannerCount);
+	}
+
+}

--- a/src/main/java/com/gaaji/auth/repository/JpaReviewRepository.java
+++ b/src/main/java/com/gaaji/auth/repository/JpaReviewRepository.java
@@ -26,4 +26,6 @@ public interface JpaReviewRepository extends JpaRepository<Review, ReviewId>{
 
 	List<Review> findDistinctByReceiverIdAndBadMannersNotNull(AuthId receiverId);
 
+	List<Review> findTop3ByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId receiverId);
+
 }

--- a/src/main/java/com/gaaji/auth/repository/ReviewRepository.java
+++ b/src/main/java/com/gaaji/auth/repository/ReviewRepository.java
@@ -31,4 +31,6 @@ public interface ReviewRepository {
 
 	List<Review> findDistinctByReceiverIdAndBadMannersNotNull(AuthId receiverId);
 
+	List<Review> findTop3ByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId receiverId);
+
 }

--- a/src/main/java/com/gaaji/auth/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/gaaji/auth/repository/ReviewRepositoryImpl.java
@@ -55,6 +55,12 @@ public class ReviewRepositoryImpl implements ReviewRepository {
 		return this.jpaReviewRepository.findDistinctByReceiverIdAndBadMannersNotNull(receiverId);
 	}
 
+	@Override
+	public List<Review> findTop3ByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(
+			AuthId receiverId) {
+		return this.jpaReviewRepository.findTop3ByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(receiverId);
+	}
+
 
 
 }

--- a/src/test/java/com/gaaji/auth/repository/ReviewRetriveJpaTest.java
+++ b/src/test/java/com/gaaji/auth/repository/ReviewRetriveJpaTest.java
@@ -122,5 +122,29 @@ public class ReviewRetriveJpaTest {
 		
 		
 	}
+	
+	@Test
+	void 후기3개조회테스트() {
+		List<GoodManner> good = new ArrayList<GoodManner>();
+		good.add(GoodManner.gm1);
+		List<BadManner> bad = new ArrayList<BadManner>();
+		bad.add(BadManner.bm2);
+		Review review1 = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
+
+		Review review2 = Review.of(ReviewId.of("review1"), PostId.of("post2"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진1", "내용2", "남가좌동", true));
+		Review review3 = Review.of(ReviewId.of("review2"), PostId.of("post3"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진2", "내용3", "남가좌동", true));
+
+		Review review = Review.of(ReviewId.of("review3"), PostId.of("post1"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진3", "내용1", "남가좌동", true));
+
+		this.jpaReviewRepository.save(review);
+		this.jpaReviewRepository.save(review1);
+		this.jpaReviewRepository.save(review2);
+		this.jpaReviewRepository.save(review3);
+		
+		List<Review> reviewList = this.jpaReviewRepository.findTop3ByReceiverIdAndComment_ContentsIsNotNullOrderByComment_CreatedAtDesc(AuthId.of("receiver"));
+		
+		assertThat(reviewList.size()).isEqualTo(3);
+		
+	}
 
 }

--- a/src/test/java/com/gaaji/auth/service/ReviewRetriveServiceTest.java
+++ b/src/test/java/com/gaaji/auth/service/ReviewRetriveServiceTest.java
@@ -18,6 +18,7 @@ import com.gaaji.auth.controller.dto.BadMannerCount;
 import com.gaaji.auth.controller.dto.CommentRetrieveResponse;
 import com.gaaji.auth.controller.dto.GoodMannerCount;
 import com.gaaji.auth.controller.dto.MannerRetrieveResponse;
+import com.gaaji.auth.controller.dto.PreviewReviewRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewRetrieveResponse;
 import com.gaaji.auth.controller.dto.ReviewUpdateRequest;
 import com.gaaji.auth.domain.Auth;
@@ -170,4 +171,43 @@ public class ReviewRetriveServiceTest {
 	assertThat(badMannerCount.get(2).getCount()).isEqualTo(1);
 	}
 	
+	@Test
+	void 후기3개조회서비스 (){
+	List<GoodManner> good = new ArrayList<GoodManner>();
+	good.add(GoodManner.gm1);
+	good.add(GoodManner.gm2);
+	
+	List<BadManner> bad = new ArrayList<BadManner>();
+	bad.add(BadManner.bm2);
+	bad.add(BadManner.bm5);
+	
+	List<GoodManner> good1 = new ArrayList<GoodManner>();
+	good1.add(GoodManner.gm1);
+	good1.add(GoodManner.gm3);
+	good1.add(GoodManner.gm4);
+
+	
+	List<BadManner> bad1 = new ArrayList<BadManner>();
+	bad1.add(BadManner.bm2);
+	bad1.add(BadManner.bm3);
+	bad1.add(BadManner.bm5);
+	
+	Review review = Review.of(ReviewId.of("review"), PostId.of("post"), AuthId.of("sender"), AuthId.of("receiver"), good, bad, Comment.of("사진", "내용", "남가좌동", true));
+	Review review1 = Review.of(ReviewId.of("review1"), PostId.of("post1"), AuthId.of("sender"), AuthId.of("receiver"), good, bad1, Comment.of("사진", null, "남가좌동", true));
+	Review review2 = Review.of(ReviewId.of("review2"), PostId.of("post2"), AuthId.of("sender1"), AuthId.of("receiver"), good1, bad, Comment.of("사진", "내용1", "남가좌동", false));
+
+	this.jpaReviewRepository.save(review);
+	this.jpaReviewRepository.save(review1);
+	this.jpaReviewRepository.save(review2);		
+	
+
+	PreviewReviewRetrieveResponse reviewList = this.reviewRetriveService.retriveReview("receiver");
+	
+	assertThat(reviewList.getGoodMannerCount().size()).isEqualTo(3);
+	assertThat(reviewList.getCommentInfo().size()).isEqualTo(2);
+
+	
+	
+	
+	}
 }


### PR DESCRIPTION
# Issue# - Issue
## Description
> Gm 253 유저 매너평가 조회(일부 미리보기)

## PR Type
- [ ] Hotfix
- [X] Feature
- [ ] Code style update
- [ ] Refactor (code, package, etc.)
- [ ] Build (gradle, spring, etc) 
- [ ] Documentation content changes (api docs, etc.)
- [ ] Infra (cloud, security, etc.)
- [ ] Other... Please describe :

## Related Issues
- GM 251

## Issues
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/48744386/221523563-319c0618-cd2a-4e19-9a6a-da20caddc3bc.png">
간단하게 기존의 매너평가 후기와 긍정 매너평가를 가져오는 로직에서 3개만 가져오도록 구현했다
### Test
  
<img width="808" alt="image" src="https://user-images.githubusercontent.com/48744386/221524080-d9e51cea-50e7-4a5e-a4be-020b225b755e.png">

<img width="319" alt="image" src="https://user-images.githubusercontent.com/48744386/221524025-e4df0d2f-4db4-4edb-9ba8-b717f0eb24fb.png">

***  4개 이상일 때, 3가지만 가져오는지와 3개 이하일 때 그만큼을 가져오는지 테스트 했다.

## Related Files
- ReviewRetriveService
- ReviewRetriveController

## Think About..  

## Conclusion  
> 유저 매너평가 조회 끝
